### PR TITLE
made changes to support secure AWS access and secrets

### DIFF
--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -1,0 +1,4 @@
+apache-airflow-providers-snowflake==1.3.0
+apache-airflow-providers-amazon
+psycopg2-binary==2.8.6
+aws-batch

--- a/docker/config/airflow.cfg
+++ b/docker/config/airflow.cfg
@@ -301,13 +301,13 @@ statsd_datadog_tags =
 [secrets]
 # Full class name of secrets backend to enable (will precede env vars and metastore in search path)
 # Example: backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
-backend =
+backend = airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
 
 # The backend_kwargs param is loaded into a dictionary and passed to __init__ of secrets backend class.
 # See documentation for the secrets backend you are using. JSON is expected.
 # Example for AWS Systems Manager ParameterStore:
 # ``{{"connections_prefix": "/airflow/connections", "profile_name": "default"}}``
-backend_kwargs =
+backend_kwargs = {'connections_prefix' : 'airflow/connections', 'variables_prefix' : 'airflow/variables',"region_name":"us-west-2"}
 
 [cli]
 # In what way should the cli access the API. The LocalClient will use the

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,6 +21,10 @@ services:
         environment:
             - LOAD_EX=n
             - EXECUTOR=Local
+            - AWS_DEFAULT_REGION=us-west-2
+            - AWS_REGION=us-west-2
+            - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+            - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
         logging:
             options:
                 max-size: 10m


### PR DESCRIPTION
Made changes to support using AWS secrets. Requires AWS environment variables to be set on the host. My local environment has been running using this configuration for the last month; I've been able to successfully develop, test and execute DAGs locally, including snowflake connectivity and accessing AWS secrets.